### PR TITLE
Better Management of WIT and caller-utils generation logs.

### DIFF
--- a/src/build/caller_utils_generator.rs
+++ b/src/build/caller_utils_generator.rs
@@ -387,9 +387,12 @@ fn generate_async_function(signature: &SignatureStruct) -> String {
         }
     }
 
-     // First parameter is always target
+    // First parameter is always target
     let all_params = if target_param.is_empty() {
-        warn!("No 'target' parameter found in signature for {}", full_function_name);
+        warn!(
+            "No 'target' parameter found in signature for {}",
+            full_function_name
+        );
         params.join(", ")
     } else {
         format!(
@@ -579,7 +582,10 @@ crate-type = ["cdylib", "lib"]
         }
     }
 
-    info!(count = wit_files.len(), "Found WIT interface files for stub generation");
+    info!(
+        count = wit_files.len(),
+        "Found WIT interface files for stub generation"
+    );
 
     // Generate content for each module and collect types
     let mut module_contents = HashMap::<String, String>::new();
@@ -695,7 +701,6 @@ crate-type = ["cdylib", "lib"]
     fs::write(&lib_rs_path, lib_rs)
         .with_context(|| format!("Failed to write lib.rs: {}", lib_rs_path.display()))?;
 
-
     info!("Created single lib.rs file with all modules inline");
 
     // Create target/wit directory and copy all WIT files
@@ -791,7 +796,9 @@ fn update_workspace_cargo_toml(base_dir: &Path) -> Result<()> {
 
                     info!("Successfully updated workspace Cargo.toml");
                 } else {
-                    debug!("Workspace Cargo.toml already up-to-date regarding caller-utils member.");
+                    debug!(
+                        "Workspace Cargo.toml already up-to-date regarding caller-utils member."
+                    );
                 }
             }
         }
@@ -803,7 +810,10 @@ fn update_workspace_cargo_toml(base_dir: &Path) -> Result<()> {
 // Add caller-utils as a dependency to hyperware:process crates
 #[instrument(skip(projects))]
 pub fn add_caller_utils_to_projects(projects: &[PathBuf]) -> Result<()> {
-    info!(count = projects.len(), "Adding caller-utils dependency to projects");
+    info!(
+        count = projects.len(),
+        "Adding caller-utils dependency to projects"
+    );
     for project_path in projects {
         let cargo_toml_path = project_path.join("Cargo.toml");
         debug!(

--- a/src/build/caller_utils_generator.rs
+++ b/src/build/caller_utils_generator.rs
@@ -701,7 +701,6 @@ crate-type = ["cdylib", "lib"]
     fs::write(&lib_rs_path, lib_rs)
         .with_context(|| format!("Failed to write lib.rs: {}", lib_rs_path.display()))?;
 
-
     // Create target/wit directory and copy all WIT files
     let target_wit_dir = caller_utils_dir.join("target").join("wit");
     debug!("Creating directory: {}", target_wit_dir.display());

--- a/src/build/caller_utils_generator.rs
+++ b/src/build/caller_utils_generator.rs
@@ -84,7 +84,6 @@ fn find_world_names(api_dir: &Path) -> Result<Vec<String>> {
 }
 
 // Convert WIT type to Rust type - IMPROVED with more Rust primitives
-#[instrument(level = "trace", skip_all)]
 fn wit_type_to_rust(wit_type: &str) -> String {
     match wit_type {
         // Integer types
@@ -144,7 +143,6 @@ fn wit_type_to_rust(wit_type: &str) -> String {
 }
 
 // Generate default value for Rust type - IMPROVED with additional types
-#[instrument(level = "trace", skip_all)]
 fn generate_default_value(rust_type: &str) -> String {
     match rust_type {
         // Integer types

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -671,7 +671,6 @@ fn get_most_recent_modified_time(
         return Err(eyre!("Didn't find required dirs: {must_exist_dirs:?}"));
     }
 
-
     Ok((most_recent, most_recent_excluded))
 }
 

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -671,7 +671,6 @@ fn get_most_recent_modified_time(
         return Err(eyre!("Didn't find required dirs: {must_exist_dirs:?}"));
     }
 
-    debug!("get_most_recent_modified_time: most_recent: {most_recent:?}, most_recent_excluded: {most_recent_excluded:?}");
 
     Ok((most_recent, most_recent_excluded))
 }

--- a/src/build/wit_generator.rs
+++ b/src/build/wit_generator.rs
@@ -239,7 +239,6 @@ fn rust_type_to_wit(ty: &Type, used_types: &mut HashSet<String>) -> Result<Strin
 }
 
 // Find all Rust files in a crate directory
-#[instrument(level = "trace", skip_all)]
 fn find_rust_files(crate_path: &Path) -> Vec<PathBuf> {
     let mut rust_files = Vec::new();
     let src_dir = crate_path.join("src");
@@ -515,7 +514,6 @@ fn collect_type_definitions_from_file(
 }
 
 // Find all relevant Rust projects
-#[instrument(level = "trace", skip_all)]
 fn find_rust_projects(base_dir: &Path) -> Vec<PathBuf> {
     let mut projects = Vec::new();
     debug!("Scanning for Rust projects in {}", base_dir.display());

--- a/src/build/wit_generator.rs
+++ b/src/build/wit_generator.rs
@@ -774,14 +774,8 @@ fn process_rust_project(project_path: &Path, api_dir: &Path) -> Result<Option<(S
                     .attrs
                     .iter()
                     .any(|attr| attr.path().is_ident("local"));
-                let has_http = method
-                    .attrs
-                    .iter()
-                    .any(|attr| attr.path().is_ident("http"));
-                let has_init = method
-                    .attrs
-                    .iter()
-                    .any(|attr| attr.path().is_ident("init"));
+                let has_http = method.attrs.iter().any(|attr| attr.path().is_ident("http"));
+                let has_init = method.attrs.iter().any(|attr| attr.path().is_ident("init"));
 
                 if has_remote || has_local || has_http || has_init {
                     debug!(remote = %has_remote, local = %has_local, http = %has_http, init = %has_init, "Method attributes");
@@ -791,7 +785,7 @@ fn process_rust_project(project_path: &Path, api_dir: &Path) -> Result<Option<(S
                         Ok(_) => {
                             // Convert function name to kebab-case
                             let func_kebab_name = to_kebab_case(&method_name); // Use different var name
-                            
+
                             debug!(original_name = %method_name, kebab_name = %func_kebab_name, "Processing method");
 
                             if has_init {
@@ -1118,10 +1112,10 @@ pub fn generate_wit_files(base_dir: &Path, api_dir: &Path) -> Result<(Vec<PathBu
             }
             Ok(None) => {
                 warn!(project_path = %project_path.display(), "No import statement generated for project");
-            },
+            }
             Err(e) => {
                 warn!(project_path = %project_path.display(), error = %e, "Error processing project");
-            },
+            }
         }
     }
 

--- a/src/build/wit_generator.rs
+++ b/src/build/wit_generator.rs
@@ -8,8 +8,8 @@ use color_eyre::{
 };
 use syn::{self, Attribute, ImplItem, Item, Type};
 use toml::Value;
-use walkdir::WalkDir;
 use tracing::{debug, info, instrument, warn};
+use walkdir::WalkDir;
 
 // Helper functions for naming conventions
 fn to_kebab_case(s: &str) -> String {
@@ -73,7 +73,6 @@ fn remove_state_suffix(name: &str) -> String {
     }
     name.to_string()
 }
-
 
 // Extract wit_world from the #[hyperprocess] attribute using the format in the debug representation
 #[instrument(skip(attrs))]
@@ -409,7 +408,7 @@ fn collect_type_definitions_from_file(
                         // --- Check if this type is used ---
                         if !used_types.contains(&name) {
                             warn!("  Skipping unused enum: {} -> {}", orig_name, name); // Optional debug log
-                                continue; // Skip this enum if not in the used set
+                            continue; // Skip this enum if not in the used set
                         }
                         // --- End Check ---
 
@@ -825,10 +824,9 @@ fn process_rust_project(project_path: &Path, api_dir: &Path) -> Result<Option<(S
                                     &mut used_types, // Pass the main set
                                 ) {
                                     Ok(remote_struct) => signature_structs.push(remote_struct),
-                                    Err(e) => warn!(
-                                        "    Error generating remote signature struct: {}",
-                                        e
-                                    ),
+                                    Err(e) => {
+                                        warn!("    Error generating remote signature struct: {}", e)
+                                    }
                                 }
                             }
 
@@ -840,10 +838,9 @@ fn process_rust_project(project_path: &Path, api_dir: &Path) -> Result<Option<(S
                                     &mut used_types, // Pass the main set
                                 ) {
                                     Ok(local_struct) => signature_structs.push(local_struct),
-                                    Err(e) => warn!(
-                                        "    Error generating local signature struct: {}",
-                                        e
-                                    ),
+                                    Err(e) => {
+                                        warn!("    Error generating local signature struct: {}", e)
+                                    }
                                 }
                             }
 
@@ -855,10 +852,9 @@ fn process_rust_project(project_path: &Path, api_dir: &Path) -> Result<Option<(S
                                     &mut used_types, // Pass the main set
                                 ) {
                                     Ok(http_struct) => signature_structs.push(http_struct),
-                                    Err(e) => warn!(
-                                        "    Error generating HTTP signature struct: {}",
-                                        e
-                                    ),
+                                    Err(e) => {
+                                        warn!("    Error generating HTTP signature struct: {}", e)
+                                    }
                                 }
                             }
                         }

--- a/src/build/wit_generator.rs
+++ b/src/build/wit_generator.rs
@@ -801,12 +801,19 @@ fn process_rust_project(project_path: &Path, api_dir: &Path) -> Result<Option<(S
                     .attrs
                     .iter()
                     .any(|attr| attr.path().is_ident("local"));
-                let has_http = method.attrs.iter().any(|attr| attr.path().is_ident("http"));
+                let has_http = method
+                    .attrs
+                    .iter()
+                    .any(|attr| attr.path().is_ident("http"));
+                let has_init = method
+                    .attrs
+                    .iter()
+                    .any(|attr| attr.path().is_ident("init"));
 
-                if has_remote || has_local || has_http {
+                if has_remote || has_local || has_http || has_init {
                     debug!(
-                        "    Has relevant attributes: remote={}, local={}, http={}",
-                        has_remote, has_local, has_http
+                        "    Has relevant attributes: remote={}, local={}, http={}, init={}",
+                        has_remote, has_local, has_http, has_init
                     );
 
                     // Validate function name
@@ -814,12 +821,19 @@ fn process_rust_project(project_path: &Path, api_dir: &Path) -> Result<Option<(S
                         Ok(_) => {
                             // Convert function name to kebab-case
                             let func_kebab_name = to_kebab_case(&method_name); // Use different var name
+                            
                             debug!(
                                 "    Processing method: {} -> {}",
                                 method_name, func_kebab_name
                             );
 
-                            // Generate a signature struct for each attribute type
+                            if has_init {
+                                debug!(
+                                    "    Found initialization function: {}",
+                                    method_name
+                                );
+                                continue;
+                            }
                             // This will populate `used_types`
                             if has_remote {
                                 match generate_signature_struct(
@@ -868,7 +882,7 @@ fn process_rust_project(project_path: &Path, api_dir: &Path) -> Result<Option<(S
                         }
                     }
                 } else {
-                    warn!("    Method {} does not have the [remote], [local], or [http], and will not be included in the WIT file", method_name);
+                    warn!("   Method {} does not have the [remote], [local], [http] or [init] attribute, it should not be in the Impl block", method_name);
                 }
             }
         }

--- a/src/build/wit_generator.rs
+++ b/src/build/wit_generator.rs
@@ -327,7 +327,9 @@ fn collect_type_definitions_from_file(
                                             Ok(_) => {
                                                 let field_name = to_kebab_case(&field_orig_name);
                                                 if field_name.is_empty() {
-                                                    warn!("Skipping field with empty name conversion");
+                                                    warn!(
+                                                        "Skipping field with empty name conversion"
+                                                    );
                                                     continue;
                                                 }
 
@@ -339,10 +341,7 @@ fn collect_type_definitions_from_file(
                                                 ) {
                                                     Ok(ty) => ty,
                                                     Err(e) => {
-                                                        warn!(
-                                                            "Error converting field type: {}",
-                                                            e
-                                                        );
+                                                        warn!("Error converting field type: {}", e);
                                                         // Propagate error if field type conversion fails
                                                         return Err(e);
                                                     }
@@ -407,7 +406,10 @@ fn collect_type_definitions_from_file(
 
                         // --- Check if this type is used ---
                         if !used_types.contains(&name) {
-                            warn!("  Skipping type not present in any function signature: {} -> {}", orig_name, name); // Optional debug log
+                            warn!(
+                                "  Skipping type not present in any function signature: {} -> {}",
+                                orig_name, name
+                            ); // Optional debug log
                             continue; // Skip this enum if not in the used set
                         }
                         // --- End Check ---
@@ -547,7 +549,10 @@ fn find_rust_projects(base_dir: &Path) -> Vec<PathBuf> {
             .and_then(|p| p.get("metadata"))
             .and_then(|m| m.get("component"))
         else {
-            warn!("  No package.metadata.component metadata found in {}", cargo_toml.display()); // Added path context
+            warn!(
+                "  No package.metadata.component metadata found in {}",
+                cargo_toml.display()
+            ); // Added path context
             continue;
         };
         let Some(package) = metadata.get("package") else {
@@ -1138,7 +1143,6 @@ pub fn generate_wit_files(base_dir: &Path, api_dir: &Path) -> Result<(Vec<PathBu
 
     let mut wit_worlds = HashSet::new();
     for project_path in &projects {
-
         match process_rust_project(project_path, api_dir) {
             Ok(Some((interface, wit_world))) => {
                 new_imports.push(format!("    import {interface};"));
@@ -1148,7 +1152,10 @@ pub fn generate_wit_files(base_dir: &Path, api_dir: &Path) -> Result<(Vec<PathBu
 
                 wit_worlds.insert(wit_world);
             }
-            Ok(None) => warn!("No import statement generated for project: {}", project_path.display()), // Add path context
+            Ok(None) => warn!(
+                "No import statement generated for project: {}",
+                project_path.display()
+            ), // Add path context
             Err(e) => warn!("Error processing project {}: {}", project_path.display(), e), // Add path context
         }
     }

--- a/src/build/wit_generator.rs
+++ b/src/build/wit_generator.rs
@@ -75,7 +75,7 @@ fn remove_state_suffix(name: &str) -> String {
 }
 
 // Extract wit_world from the #[hyperprocess] attribute using the format in the debug representation
-#[instrument(skip(attrs))]
+#[instrument(level = "trace", skip_all)]
 fn extract_wit_world(attrs: &[Attribute]) -> Result<String> {
     for attr in attrs {
         if attr.path().is_ident("hyperprocess") {
@@ -106,7 +106,7 @@ fn extract_wit_world(attrs: &[Attribute]) -> Result<String> {
 }
 
 // Convert Rust type to WIT type, including downstream types
-#[instrument(level = "debug", skip(ty, used_types))]
+#[instrument(level = "trace", skip_all)]
 fn rust_type_to_wit(ty: &Type, used_types: &mut HashSet<String>) -> Result<String> {
     match ty {
         Type::Path(type_path) => {
@@ -239,7 +239,7 @@ fn rust_type_to_wit(ty: &Type, used_types: &mut HashSet<String>) -> Result<Strin
 }
 
 // Find all Rust files in a crate directory
-#[instrument]
+#[instrument(level = "trace", skip_all)]
 fn find_rust_files(crate_path: &Path) -> Vec<PathBuf> {
     let mut rust_files = Vec::new();
     let src_dir = crate_path.join("src");
@@ -264,13 +264,13 @@ fn find_rust_files(crate_path: &Path) -> Vec<PathBuf> {
 }
 
 // Collect **only used** type definitions (structs and enums) from a file
-#[instrument(skip(used_types))]
+#[instrument(level = "trace", skip_all)]
 fn collect_type_definitions_from_file(
     file_path: &Path,
     used_types: &HashSet<String>, // Accept the set of used types
 ) -> Result<HashMap<String, String>> {
     debug!(
-        "Collecting used type definitions from file: {}", // Updated message
+        "Collecting used type definitions from file: {}",
         file_path.display()
     );
 
@@ -291,7 +291,7 @@ fn collect_type_definitions_from_file(
                 // Skip trying to validate if name contains "__" as these are likely internal types
                 if orig_name.contains("__") {
                     // This skip can remain, as internal types are unlikely to be in `used_types` anyway
-                    warn!("  Skipping likely internal struct: {}", orig_name);
+                    warn!("Skipping likely internal struct: {}", orig_name);
                     continue;
                 }
 
@@ -307,7 +307,7 @@ fn collect_type_definitions_from_file(
                         }
                         // --- End Check ---
 
-                        debug!("  Found used struct: {} -> {}", orig_name, name); // Updated message
+                        debug!("  Found used struct: {} -> {}", orig_name, name);
 
                         // Proceed with field processing only if the struct is used
                         let fields: Vec<String> = match &item_struct.fields {
@@ -327,7 +327,7 @@ fn collect_type_definitions_from_file(
                                             Ok(_) => {
                                                 let field_name = to_kebab_case(&field_orig_name);
                                                 if field_name.is_empty() {
-                                                    warn!("    Skipping field with empty name conversion");
+                                                    warn!("Skipping field with empty name conversion");
                                                     continue;
                                                 }
 
@@ -340,7 +340,7 @@ fn collect_type_definitions_from_file(
                                                     Ok(ty) => ty,
                                                     Err(e) => {
                                                         warn!(
-                                                            "    Error converting field type: {}",
+                                                            "Error converting field type: {}",
                                                             e
                                                         );
                                                         // Propagate error if field type conversion fails
@@ -407,12 +407,12 @@ fn collect_type_definitions_from_file(
 
                         // --- Check if this type is used ---
                         if !used_types.contains(&name) {
-                            warn!("  Skipping unused enum: {} -> {}", orig_name, name); // Optional debug log
+                            warn!("  Skipping type not present in any function signature: {} -> {}", orig_name, name); // Optional debug log
                             continue; // Skip this enum if not in the used set
                         }
                         // --- End Check ---
 
-                        debug!("  Found used enum: {} -> {}", orig_name, name); // Updated message
+                        debug!("  Found used enum: {} -> {}", orig_name, name);
 
                         // Proceed with variant processing only if the enum is used
                         let mut variants = Vec::new();
@@ -508,12 +508,12 @@ fn collect_type_definitions_from_file(
     debug!(
         "Collected {} used type definitions from this file",
         type_defs.len()
-    ); // Updated message
+    );
     Ok(type_defs)
 }
 
 // Find all relevant Rust projects
-#[instrument]
+#[instrument(level = "trace", skip_all)]
 fn find_rust_projects(base_dir: &Path) -> Vec<PathBuf> {
     let mut projects = Vec::new();
     debug!("Scanning for Rust projects in {}", base_dir.display());
@@ -547,7 +547,7 @@ fn find_rust_projects(base_dir: &Path) -> Vec<PathBuf> {
             .and_then(|p| p.get("metadata"))
             .and_then(|m| m.get("component"))
         else {
-            warn!("  No package.metadata.component metadata found");
+            warn!("  No package.metadata.component metadata found in {}", cargo_toml.display()); // Added path context
             continue;
         };
         let Some(package) = metadata.get("package") else {
@@ -561,7 +561,7 @@ fn find_rust_projects(base_dir: &Path) -> Vec<PathBuf> {
             package_str
         );
         if package_str == "hyperware:process" {
-            info!("  Adding project: {}", path.display());
+            debug!("  Adding project: {}", path.display()); // INFO -> DEBUG
             projects.push(path.to_path_buf());
         }
     }
@@ -571,7 +571,7 @@ fn find_rust_projects(base_dir: &Path) -> Vec<PathBuf> {
 }
 
 // Helper function to generate signature struct for specific attribute type
-#[instrument(skip(used_types))]
+#[instrument(level = "trace", skip_all)]
 fn generate_signature_struct(
     kebab_name: &str,
     attr_type: &str,
@@ -680,7 +680,7 @@ impl AsTypePath for syn::Type {
 }
 
 // Process a single Rust project and generate WIT files
-#[instrument(skip_all)]
+#[instrument(level = "trace", skip_all)]
 fn process_rust_project(project_path: &Path, api_dir: &Path) -> Result<Option<(String, String)>> {
     info!("Processing project: {}", project_path.display());
 
@@ -759,9 +759,9 @@ fn process_rust_project(project_path: &Path, api_dir: &Path) -> Result<Option<(S
                     // Convert to kebab-case for file name and interface name
                     kebab_interface_name = Some(to_kebab_case(&base_name));
 
-                    info!("Interface name: {:?}", interface_name);
-                    info!("Base name: {}", base_name);
-                    info!("Kebab interface name: {:?}", kebab_interface_name);
+                    debug!("Interface name: {:?}", interface_name);
+                    debug!("Base name: {}", base_name);
+                    debug!("Kebab interface name: {:?}", kebab_interface_name);
 
                     // Save the impl item for later processing
                     impl_item_with_hyperprocess = Some(impl_item.clone());
@@ -809,7 +809,7 @@ fn process_rust_project(project_path: &Path, api_dir: &Path) -> Result<Option<(S
                         Ok(_) => {
                             // Convert function name to kebab-case
                             let func_kebab_name = to_kebab_case(&method_name); // Use different var name
-                            info!(
+                            debug!(
                                 "    Processing method: {} -> {}",
                                 method_name, func_kebab_name
                             );
@@ -863,7 +863,7 @@ fn process_rust_project(project_path: &Path, api_dir: &Path) -> Result<Option<(S
                         }
                     }
                 } else {
-                    warn!("    Skipping method without relevant attributes");
+                    warn!("    Method {} does not have the [remote], [local], or [http], and will not be included in the WIT file", method_name);
                 }
             }
         }
@@ -947,15 +947,15 @@ fn process_rust_project(project_path: &Path, api_dir: &Path) -> Result<Option<(S
 
             // Write the interface file with kebab-case name
             let interface_file = api_dir.join(format!("{}.wit", kebab_name));
-            info!("Writing WIT file to {}", interface_file.display());
+            debug!("Writing WIT file to {}", interface_file.display());
 
             fs::write(&interface_file, &final_content)
                 .with_context(|| format!("Failed to write {}", interface_file.display()))?;
 
-            info!("Successfully wrote WIT file");
+            debug!("Successfully wrote WIT file");
         }
     } else {
-        warn!("No valid hyperprocess interface found in lib.rs"); // More specific message
+        warn!("No valid hyperprocess interface found in lib.rs");
     }
 
     // Return statement remains the same logic
@@ -970,13 +970,14 @@ fn process_rust_project(project_path: &Path, api_dir: &Path) -> Result<Option<(S
         Ok(None)
     }
 }
-#[instrument(skip(new_imports, wit_worlds, updated_world))]
+#[instrument(level = "trace", skip_all)]
 fn rewrite_wit(
     api_dir: &Path,
     new_imports: &Vec<String>,
     wit_worlds: &mut HashSet<String>,
     updated_world: &mut bool,
 ) -> Result<()> {
+    debug!("Rewriting WIT world files in {}", api_dir.display());
     // handle existing api files
     for entry in WalkDir::new(api_dir)
         .max_depth(1)
@@ -1031,13 +1032,13 @@ fn rewrite_wit(
                     &mut include_lines,
                 )?;
 
-                info!("Writing updated world definition to {}", path.display());
+                debug!("Writing updated world definition to {}", path.display());
                 // Write the updated world file
                 fs::write(path, world_content).with_context(|| {
                     format!("Failed to write updated world file: {}", path.display())
                 })?;
 
-                info!("Successfully updated world definition");
+                debug!("Successfully updated world definition"); // INFO -> DEBUG
                 *updated_world = true;
             }
         }
@@ -1051,13 +1052,13 @@ fn rewrite_wit(
                 generate_wit_file(&wit_world, new_imports, &Vec::new(), &mut HashSet::new())?;
 
             let path = api_dir.join(format!("{wit_world}.wit"));
-            info!("Writing updated world definition to {}", path.display());
+            debug!("Writing updated world definition to {}", path.display());
             // Write the updated world file
             fs::write(&path, world_content).with_context(|| {
                 format!("Failed to write updated world file: {}", path.display())
             })?;
 
-            info!("Successfully created new world definition for {wit_world}");
+            debug!("Successfully created new world definition for {wit_world}");
         }
         *updated_world = true;
     }
@@ -1116,8 +1117,10 @@ fn generate_wit_file(
 }
 
 // Generate WIT files from Rust code
-#[instrument(skip(base_dir, api_dir))]
+#[instrument(level = "trace", skip_all)]
 pub fn generate_wit_files(base_dir: &Path, api_dir: &Path) -> Result<(Vec<PathBuf>, Vec<String>)> {
+    // Keep INFO for start
+    info!("Generating WIT files...");
     fs::create_dir_all(&api_dir)?;
 
     // Find all relevant Rust projects
@@ -1135,7 +1138,6 @@ pub fn generate_wit_files(base_dir: &Path, api_dir: &Path) -> Result<(Vec<PathBu
 
     let mut wit_worlds = HashSet::new();
     for project_path in &projects {
-        info!("Processing project: {}", project_path.display());
 
         match process_rust_project(project_path, api_dir) {
             Ok(Some((interface, wit_world))) => {
@@ -1146,8 +1148,8 @@ pub fn generate_wit_files(base_dir: &Path, api_dir: &Path) -> Result<(Vec<PathBu
 
                 wit_worlds.insert(wit_world);
             }
-            Ok(None) => warn!("No import statement generated"),
-            Err(e) => warn!("Error processing project: {}", e),
+            Ok(None) => warn!("No import statement generated for project: {}", project_path.display()), // Add path context
+            Err(e) => warn!("Error processing project {}: {}", project_path.display(), e), // Add path context
         }
     }
 
@@ -1195,7 +1197,7 @@ pub fn generate_wit_files(base_dir: &Path, api_dir: &Path) -> Result<(Vec<PathBu
         );
 
         let world_file = api_dir.join(format!("{}.wit", default_world));
-        info!(
+        debug!(
             "Writing default world definition to {}",
             world_file.display()
         );
@@ -1207,7 +1209,7 @@ pub fn generate_wit_files(base_dir: &Path, api_dir: &Path) -> Result<(Vec<PathBu
             )
         })?;
 
-        info!("Successfully created default world definition");
+        debug!("Successfully created default world definition");
     }
 
     info!("WIT files generated successfully in the 'api' directory.");

--- a/src/build/wit_generator.rs
+++ b/src/build/wit_generator.rs
@@ -687,7 +687,7 @@ impl AsTypePath for syn::Type {
 // Process a single Rust project and generate WIT files
 #[instrument(level = "trace", skip_all)]
 fn process_rust_project(project_path: &Path, api_dir: &Path) -> Result<Option<(String, String)>> {
-    info!("Processing project: {}", project_path.display());
+    debug!("Processing project: {}", project_path.display());
 
     // Find lib.rs for this project
     let lib_rs = project_path.join("src").join("lib.rs");

--- a/src/build/wit_generator.rs
+++ b/src/build/wit_generator.rs
@@ -9,6 +9,7 @@ use color_eyre::{
 use syn::{self, Attribute, ImplItem, Item, Type};
 use toml::Value;
 use walkdir::WalkDir;
+use tracing::{debug, info, instrument, warn};
 
 // Helper functions for naming conventions
 fn to_kebab_case(s: &str) -> String {
@@ -73,17 +74,19 @@ fn remove_state_suffix(name: &str) -> String {
     name.to_string()
 }
 
+
 // Extract wit_world from the #[hyperprocess] attribute using the format in the debug representation
+#[instrument(skip(attrs))]
 fn extract_wit_world(attrs: &[Attribute]) -> Result<String> {
     for attr in attrs {
         if attr.path().is_ident("hyperprocess") {
             // Convert attribute to string representation
             let attr_str = format!("{:?}", attr);
-            println!("Attribute string: {}", attr_str);
+            debug!("Attribute string: {}", attr_str);
 
             // Look for wit_world in the attribute string
             if let Some(pos) = attr_str.find("wit_world") {
-                println!("Found wit_world at position {}", pos);
+                debug!("Found wit_world at position {}", pos);
 
                 // Find the literal value after wit_world by looking for lit: "value"
                 let lit_pattern = "lit: \"";
@@ -93,7 +96,7 @@ fn extract_wit_world(attrs: &[Attribute]) -> Result<String> {
                     // Find the closing quote of the literal
                     if let Some(quote_pos) = attr_str[start_pos..].find('\"') {
                         let world_name = &attr_str[start_pos..(start_pos + quote_pos)];
-                        println!("Extracted wit_world: {}", world_name);
+                        debug!("Extracted wit_world: {}", world_name);
                         return Ok(world_name.to_string());
                     }
                 }
@@ -104,6 +107,7 @@ fn extract_wit_world(attrs: &[Attribute]) -> Result<String> {
 }
 
 // Convert Rust type to WIT type, including downstream types
+#[instrument(level = "debug", skip(ty, used_types))]
 fn rust_type_to_wit(ty: &Type, used_types: &mut HashSet<String>) -> Result<String> {
     match ty {
         Type::Path(type_path) => {
@@ -236,35 +240,37 @@ fn rust_type_to_wit(ty: &Type, used_types: &mut HashSet<String>) -> Result<Strin
 }
 
 // Find all Rust files in a crate directory
+#[instrument]
 fn find_rust_files(crate_path: &Path) -> Vec<PathBuf> {
     let mut rust_files = Vec::new();
     let src_dir = crate_path.join("src");
 
-    println!("Finding Rust files in {}", src_dir.display());
+    debug!("Finding Rust files in {}", src_dir.display());
 
     if !src_dir.exists() || !src_dir.is_dir() {
-        println!("No src directory found at {}", src_dir.display());
+        warn!("No src directory found at {}", src_dir.display());
         return rust_files;
     }
 
     for entry in WalkDir::new(src_dir).into_iter().filter_map(Result::ok) {
         let path = entry.path();
         if path.is_file() && path.extension().map_or(false, |ext| ext == "rs") {
-            println!("Found Rust file: {}", path.display());
+            debug!("Found Rust file: {}", path.display());
             rust_files.push(path.to_path_buf());
         }
     }
 
-    println!("Found {} Rust files", rust_files.len());
+    debug!("Found {} Rust files", rust_files.len());
     rust_files
 }
 
 // Collect **only used** type definitions (structs and enums) from a file
+#[instrument(skip(used_types))]
 fn collect_type_definitions_from_file(
     file_path: &Path,
     used_types: &HashSet<String>, // Accept the set of used types
 ) -> Result<HashMap<String, String>> {
-    println!(
+    debug!(
         "Collecting used type definitions from file: {}", // Updated message
         file_path.display()
     );
@@ -286,7 +292,7 @@ fn collect_type_definitions_from_file(
                 // Skip trying to validate if name contains "__" as these are likely internal types
                 if orig_name.contains("__") {
                     // This skip can remain, as internal types are unlikely to be in `used_types` anyway
-                    println!("  Skipping likely internal struct: {}", orig_name);
+                    warn!("  Skipping likely internal struct: {}", orig_name);
                     continue;
                 }
 
@@ -297,12 +303,12 @@ fn collect_type_definitions_from_file(
 
                         // --- Check if this type is used ---
                         if !used_types.contains(&name) {
-                            // println!("  Skipping unused struct: {} -> {}", orig_name, name); // Optional debug log
-                            continue; // Skip this struct if not in the used set
+                            // Skip this struct if not in the used set
+                            continue;
                         }
                         // --- End Check ---
 
-                        println!("  Found used struct: {} -> {}", orig_name, name); // Updated message
+                        debug!("  Found used struct: {} -> {}", orig_name, name); // Updated message
 
                         // Proceed with field processing only if the struct is used
                         let fields: Vec<String> = match &item_struct.fields {
@@ -322,7 +328,7 @@ fn collect_type_definitions_from_file(
                                             Ok(_) => {
                                                 let field_name = to_kebab_case(&field_orig_name);
                                                 if field_name.is_empty() {
-                                                    println!("    Skipping field with empty name conversion");
+                                                    warn!("    Skipping field with empty name conversion");
                                                     continue;
                                                 }
 
@@ -334,7 +340,7 @@ fn collect_type_definitions_from_file(
                                                 ) {
                                                     Ok(ty) => ty,
                                                     Err(e) => {
-                                                        println!(
+                                                        warn!(
                                                             "    Error converting field type: {}",
                                                             e
                                                         );
@@ -343,7 +349,7 @@ fn collect_type_definitions_from_file(
                                                     }
                                                 };
 
-                                                println!(
+                                                debug!(
                                                     "    Field: {} -> {}",
                                                     field_name, field_type
                                                 );
@@ -353,7 +359,7 @@ fn collect_type_definitions_from_file(
                                                 ));
                                             }
                                             Err(e) => {
-                                                println!(
+                                                warn!(
                                                     "    Skipping field with invalid name: {}",
                                                     e
                                                 );
@@ -375,12 +381,12 @@ fn collect_type_definitions_from_file(
                                 format!("    record {} {{\n{}\n    }}", name, fields.join(",\n")),
                             );
                         } else {
-                            println!("  Skipping used struct {} with no convertible fields", name);
+                            warn!("  Skipping used struct {} with no convertible fields", name);
                         }
                     }
                     Err(e) => {
                         // Struct name validation failed, skip regardless of usage
-                        println!("  Skipping struct with invalid name: {}", e);
+                        warn!("  Skipping struct with invalid name: {}", e);
                         continue;
                     }
                 }
@@ -391,7 +397,7 @@ fn collect_type_definitions_from_file(
 
                 // Skip trying to validate if name contains "__"
                 if orig_name.contains("__") {
-                    println!("  Skipping likely internal enum: {}", orig_name);
+                    warn!("  Skipping likely internal enum: {}", orig_name);
                     continue;
                 }
 
@@ -402,12 +408,12 @@ fn collect_type_definitions_from_file(
 
                         // --- Check if this type is used ---
                         if !used_types.contains(&name) {
-                            // println!("  Skipping unused enum: {} -> {}", orig_name, name); // Optional debug log
-                            continue; // Skip this enum if not in the used set
+                            warn!("  Skipping unused enum: {} -> {}", orig_name, name); // Optional debug log
+                                continue; // Skip this enum if not in the used set
                         }
                         // --- End Check ---
 
-                        println!("  Found used enum: {} -> {}", orig_name, name); // Updated message
+                        debug!("  Found used enum: {} -> {}", orig_name, name); // Updated message
 
                         // Proceed with variant processing only if the enum is used
                         let mut variants = Vec::new();
@@ -430,7 +436,7 @@ fn collect_type_definitions_from_file(
                                                 Ok(ty) => {
                                                     let variant_name =
                                                         to_kebab_case(&variant_orig_name);
-                                                    println!(
+                                                    debug!(
                                                         "    Variant: {} -> {}({})",
                                                         variant_orig_name, variant_name, ty
                                                     );
@@ -440,7 +446,7 @@ fn collect_type_definitions_from_file(
                                                     ));
                                                 }
                                                 Err(e) => {
-                                                    println!(
+                                                    warn!(
                                                         "    Error converting variant type: {}",
                                                         e
                                                     );
@@ -451,14 +457,14 @@ fn collect_type_definitions_from_file(
                                         }
                                         syn::Fields::Unit => {
                                             let variant_name = to_kebab_case(&variant_orig_name);
-                                            println!(
+                                            debug!(
                                                 "    Variant: {} -> {}",
                                                 variant_orig_name, variant_name
                                             );
                                             variants.push(format!("        {}", variant_name));
                                         }
                                         _ => {
-                                            println!(
+                                            warn!(
                                                 "    Skipping complex variant in used enum {}: {}",
                                                 name, variant_orig_name
                                             );
@@ -468,7 +474,7 @@ fn collect_type_definitions_from_file(
                                     }
                                 }
                                 Err(e) => {
-                                    println!("    Skipping variant with invalid name in used enum {}: {}", name, e);
+                                    warn!("    Skipping variant with invalid name in used enum {}: {}", name, e);
                                     skip_enum = true; // Skip the whole enum if one variant name is invalid
                                     break;
                                 }
@@ -486,12 +492,12 @@ fn collect_type_definitions_from_file(
                                 ),
                             );
                         } else {
-                            println!("  Skipping used enum {} due to complex/invalid variants or no variants", name);
+                            warn!("  Skipping used enum {} due to complex/invalid variants or no variants", name);
                         }
                     }
                     Err(e) => {
                         // Enum name validation failed, skip regardless of usage
-                        println!("  Skipping enum with invalid name: {}", e);
+                        warn!("  Skipping enum with invalid name: {}", e);
                         continue;
                     }
                 }
@@ -500,7 +506,7 @@ fn collect_type_definitions_from_file(
         }
     }
 
-    println!(
+    debug!(
         "Collected {} used type definitions from this file",
         type_defs.len()
     ); // Updated message
@@ -508,9 +514,10 @@ fn collect_type_definitions_from_file(
 }
 
 // Find all relevant Rust projects
+#[instrument]
 fn find_rust_projects(base_dir: &Path) -> Vec<PathBuf> {
     let mut projects = Vec::new();
-    println!("Scanning for Rust projects in {}", base_dir.display());
+    debug!("Scanning for Rust projects in {}", base_dir.display());
 
     for entry in WalkDir::new(base_dir)
         .max_depth(1)
@@ -523,7 +530,7 @@ fn find_rust_projects(base_dir: &Path) -> Vec<PathBuf> {
             continue;
         }
         let cargo_toml = path.join("Cargo.toml");
-        println!("Checking {}", cargo_toml.display());
+        debug!("Checking {}", cargo_toml.display());
 
         if !cargo_toml.exists() {
             continue;
@@ -541,7 +548,7 @@ fn find_rust_projects(base_dir: &Path) -> Vec<PathBuf> {
             .and_then(|p| p.get("metadata"))
             .and_then(|m| m.get("component"))
         else {
-            println!("  No package.metadata.component metadata found");
+            warn!("  No package.metadata.component metadata found");
             continue;
         };
         let Some(package) = metadata.get("package") else {
@@ -550,21 +557,22 @@ fn find_rust_projects(base_dir: &Path) -> Vec<PathBuf> {
         let Some(package_str) = package.as_str() else {
             continue;
         };
-        println!(
+        debug!(
             "  Found package.metadata.component.package = {:?}",
             package_str
         );
         if package_str == "hyperware:process" {
-            println!("  Adding project: {}", path.display());
+            info!("  Adding project: {}", path.display());
             projects.push(path.to_path_buf());
         }
     }
 
-    println!("Found {} relevant Rust projects", projects.len());
+    debug!("Found {} relevant Rust projects", projects.len());
     projects
 }
 
 // Helper function to generate signature struct for specific attribute type
+#[instrument(skip(used_types))]
 fn generate_signature_struct(
     kebab_name: &str,
     attr_type: &str,
@@ -616,13 +624,13 @@ fn generate_signature_struct(
                                     .push(format!("        {}: {}", param_name, param_type));
                             }
                             Err(e) => {
-                                println!("    Error converting parameter type: {}", e);
+                                warn!("    Error converting parameter type: {}", e);
                                 return Err(e);
                             }
                         }
                     }
                     Err(e) => {
-                        println!("    Skipping parameter with invalid name: {}", e);
+                        warn!("    Skipping parameter with invalid name: {}", e);
                         return Err(e);
                     }
                 }
@@ -637,7 +645,7 @@ fn generate_signature_struct(
                 struct_fields.push(format!("        returning: {}", return_type));
             }
             Err(e) => {
-                println!("    Error converting return type: {}", e);
+                warn!("    Error converting return type: {}", e);
                 return Err(e);
             }
         },
@@ -673,14 +681,15 @@ impl AsTypePath for syn::Type {
 }
 
 // Process a single Rust project and generate WIT files
+#[instrument(skip_all)]
 fn process_rust_project(project_path: &Path, api_dir: &Path) -> Result<Option<(String, String)>> {
-    println!("\nProcessing project: {}", project_path.display());
+    info!("Processing project: {}", project_path.display());
 
     // Find lib.rs for this project
     let lib_rs = project_path.join("src").join("lib.rs");
 
     if !lib_rs.exists() {
-        println!("No lib.rs found for project: {}", project_path.display());
+        warn!("No lib.rs found for project: {}", project_path.display());
         return Ok(None);
     }
 
@@ -707,7 +716,7 @@ fn process_rust_project(project_path: &Path, api_dir: &Path) -> Result<Option<(S
     let mut kebab_interface_name = None;
     let mut impl_item_with_hyperprocess = None;
 
-    println!("Scanning for impl blocks with hyperprocess attribute");
+    debug!("Scanning for impl blocks with hyperprocess attribute");
     for item in &ast.items {
         let Item::Impl(impl_item) = item else {
             continue;
@@ -718,12 +727,12 @@ fn process_rust_project(project_path: &Path, api_dir: &Path) -> Result<Option<(S
             .iter()
             .find(|attr| attr.path().is_ident("hyperprocess"))
         {
-            println!("Found hyperprocess attribute");
+            debug!("Found hyperprocess attribute");
 
             // Extract the wit_world name
             match extract_wit_world(&[attr.clone()]) {
                 Ok(world_name) => {
-                    println!("Extracted wit_world: {}", world_name);
+                    debug!("Extracted wit_world: {}", world_name);
                     wit_world = Some(world_name);
 
                     // Get the interface name from the impl type
@@ -741,7 +750,7 @@ fn process_rust_project(project_path: &Path, api_dir: &Path) -> Result<Option<(S
                     };
                     // Validate the interface name
                     if let Err(e) = validate_name(name, "Interface") {
-                        println!("Interface name validation failed: {}", e);
+                        warn!("Interface name validation failed: {}", e);
                         continue; // Skip this impl block if validation fails
                     }
 
@@ -751,15 +760,15 @@ fn process_rust_project(project_path: &Path, api_dir: &Path) -> Result<Option<(S
                     // Convert to kebab-case for file name and interface name
                     kebab_interface_name = Some(to_kebab_case(&base_name));
 
-                    println!("Interface name: {:?}", interface_name);
-                    println!("Base name: {}", base_name);
-                    println!("Kebab interface name: {:?}", kebab_interface_name);
+                    info!("Interface name: {:?}", interface_name);
+                    info!("Base name: {}", base_name);
+                    info!("Kebab interface name: {:?}", kebab_interface_name);
 
                     // Save the impl item for later processing
                     impl_item_with_hyperprocess = Some(impl_item.clone());
                     break; // Assume only one hyperprocess impl block per lib.rs
                 }
-                Err(e) => println!("Failed to extract wit_world: {}", e),
+                Err(e) => warn!("Failed to extract wit_world: {}", e),
             }
         }
     }
@@ -777,7 +786,7 @@ fn process_rust_project(project_path: &Path, api_dir: &Path) -> Result<Option<(S
                     continue;
                 };
                 let method_name = method.sig.ident.to_string();
-                println!("  Examining method: {}", method_name);
+                debug!("Examining method: {}", method_name);
 
                 // Check for attribute types
                 let has_remote = method
@@ -791,7 +800,7 @@ fn process_rust_project(project_path: &Path, api_dir: &Path) -> Result<Option<(S
                 let has_http = method.attrs.iter().any(|attr| attr.path().is_ident("http"));
 
                 if has_remote || has_local || has_http {
-                    println!(
+                    debug!(
                         "    Has relevant attributes: remote={}, local={}, http={}",
                         has_remote, has_local, has_http
                     );
@@ -801,7 +810,7 @@ fn process_rust_project(project_path: &Path, api_dir: &Path) -> Result<Option<(S
                         Ok(_) => {
                             // Convert function name to kebab-case
                             let func_kebab_name = to_kebab_case(&method_name); // Use different var name
-                            println!(
+                            info!(
                                 "    Processing method: {} -> {}",
                                 method_name, func_kebab_name
                             );
@@ -816,7 +825,7 @@ fn process_rust_project(project_path: &Path, api_dir: &Path) -> Result<Option<(S
                                     &mut used_types, // Pass the main set
                                 ) {
                                     Ok(remote_struct) => signature_structs.push(remote_struct),
-                                    Err(e) => println!(
+                                    Err(e) => warn!(
                                         "    Error generating remote signature struct: {}",
                                         e
                                     ),
@@ -831,7 +840,7 @@ fn process_rust_project(project_path: &Path, api_dir: &Path) -> Result<Option<(S
                                     &mut used_types, // Pass the main set
                                 ) {
                                     Ok(local_struct) => signature_structs.push(local_struct),
-                                    Err(e) => println!(
+                                    Err(e) => warn!(
                                         "    Error generating local signature struct: {}",
                                         e
                                     ),
@@ -846,7 +855,7 @@ fn process_rust_project(project_path: &Path, api_dir: &Path) -> Result<Option<(S
                                     &mut used_types, // Pass the main set
                                 ) {
                                     Ok(http_struct) => signature_structs.push(http_struct),
-                                    Err(e) => println!(
+                                    Err(e) => warn!(
                                         "    Error generating HTTP signature struct: {}",
                                         e
                                     ),
@@ -854,16 +863,16 @@ fn process_rust_project(project_path: &Path, api_dir: &Path) -> Result<Option<(S
                             }
                         }
                         Err(e) => {
-                            println!("    Skipping method with invalid name: {}", e);
+                            warn!("    Skipping method with invalid name: {}", e);
                         }
                     }
                 } else {
-                    println!("    Skipping method without relevant attributes");
+                    warn!("    Skipping method without relevant attributes");
                 }
             }
         }
     }
-    println!(
+    debug!(
         "Identified {} used types from function signatures.",
         used_types.len()
     );
@@ -880,7 +889,7 @@ fn process_rust_project(project_path: &Path, api_dir: &Path) -> Result<Option<(S
                 }
             }
             Err(e) => {
-                println!(
+                warn!(
                     "Error collecting type definitions from {}: {}",
                     file_path.display(),
                     e
@@ -890,7 +899,7 @@ fn process_rust_project(project_path: &Path, api_dir: &Path) -> Result<Option<(S
         }
     }
 
-    println!("Collected {} used type definitions", all_type_defs.len());
+    debug!("Collected {} used type definitions", all_type_defs.len());
 
     // Now generate the WIT content for the interface
     if let (Some(ref iface_name), Some(ref kebab_name), Some(ref _impl_item)) = (
@@ -903,12 +912,12 @@ fn process_rust_project(project_path: &Path, api_dir: &Path) -> Result<Option<(S
         let mut type_defs: Vec<String> = all_type_defs.into_values().collect(); // Collect values directly
 
         type_defs.sort(); // Sort for consistent output
-        println!("Including {} used type definitions", type_defs.len());
+        debug!("Including {} used type definitions", type_defs.len());
 
         // Generate the final WIT content
         if signature_structs.is_empty() && type_defs.is_empty() {
             // Check both sigs and types
-            println!(
+            warn!(
                 "No functions or used types found for interface {}",
                 iface_name
             );
@@ -933,7 +942,7 @@ fn process_rust_project(project_path: &Path, api_dir: &Path) -> Result<Option<(S
             // Wrap in interface block
             let final_content =
                 format!("interface {} {{\n{}\n}}\n", kebab_name, content.trim_end()); // Trim trailing whitespace
-            println!(
+            debug!(
                 "Generated interface content for {} with {} signature structs and {} type definitions",
                 iface_name,
                 signature_structs.len(),
@@ -942,30 +951,30 @@ fn process_rust_project(project_path: &Path, api_dir: &Path) -> Result<Option<(S
 
             // Write the interface file with kebab-case name
             let interface_file = api_dir.join(format!("{}.wit", kebab_name));
-            println!("Writing WIT file to {}", interface_file.display());
+            info!("Writing WIT file to {}", interface_file.display());
 
             fs::write(&interface_file, &final_content)
                 .with_context(|| format!("Failed to write {}", interface_file.display()))?;
 
-            println!("Successfully wrote WIT file");
+            info!("Successfully wrote WIT file");
         }
     } else {
-        println!("No valid hyperprocess interface found in lib.rs"); // More specific message
+        warn!("No valid hyperprocess interface found in lib.rs"); // More specific message
     }
 
     // Return statement remains the same logic
     if let (Some(wit_world), Some(_), Some(kebab_iface)) =
         (wit_world, interface_name, kebab_interface_name)
     {
-        println!("Returning import statement for interface {}", kebab_iface);
+        debug!("Returning import statement for interface {}", kebab_iface);
         // Use kebab-case interface name for import
         Ok(Some((kebab_iface, wit_world)))
     } else {
-        println!("No valid interface found or wit_world extracted."); // Updated message
+        warn!("No valid interface found or wit_world extracted."); // Updated message
         Ok(None)
     }
 }
-
+#[instrument(skip(new_imports, wit_worlds, updated_world))]
 fn rewrite_wit(
     api_dir: &Path,
     new_imports: &Vec<String>,
@@ -981,7 +990,7 @@ fn rewrite_wit(
         let path = entry.path();
 
         if path.is_file() && path.extension().map_or(false, |ext| ext == "wit") {
-            println!("Checking WIT file: {}", path.display());
+            debug!("Checking WIT file: {}", path.display());
 
             let Ok(content) = fs::read_to_string(path) else {
                 continue;
@@ -989,7 +998,7 @@ fn rewrite_wit(
             if !content.contains("world ") {
                 continue;
             }
-            println!("Found world definition file");
+            debug!("Found world definition file");
 
             // Extract the world name and existing imports
             let lines: Vec<&str> = content.lines().collect();
@@ -1015,7 +1024,7 @@ fn rewrite_wit(
                 continue;
             };
 
-            println!("Extracted world name: {}", world_name);
+            debug!("Extracted world name: {}", world_name);
 
             // Check if this world name matches the one we're looking for
             if wit_worlds.remove(&world_name) || wit_worlds.contains(&world_name[6..]) {
@@ -1026,13 +1035,13 @@ fn rewrite_wit(
                     &mut include_lines,
                 )?;
 
-                println!("Writing updated world definition to {}", path.display());
+                info!("Writing updated world definition to {}", path.display());
                 // Write the updated world file
                 fs::write(path, world_content).with_context(|| {
                     format!("Failed to write updated world file: {}", path.display())
                 })?;
 
-                println!("Successfully updated world definition");
+                info!("Successfully updated world definition");
                 *updated_world = true;
             }
         }
@@ -1046,13 +1055,13 @@ fn rewrite_wit(
                 generate_wit_file(&wit_world, new_imports, &Vec::new(), &mut HashSet::new())?;
 
             let path = api_dir.join(format!("{wit_world}.wit"));
-            println!("Writing updated world definition to {}", path.display());
+            info!("Writing updated world definition to {}", path.display());
             // Write the updated world file
             fs::write(&path, world_content).with_context(|| {
                 format!("Failed to write updated world file: {}", path.display())
             })?;
 
-            println!("Successfully created new world definition for {wit_world}");
+            info!("Successfully created new world definition for {wit_world}");
         }
         *updated_world = true;
     }
@@ -1111,6 +1120,7 @@ fn generate_wit_file(
 }
 
 // Generate WIT files from Rust code
+#[instrument(skip(base_dir, api_dir))]
 pub fn generate_wit_files(base_dir: &Path, api_dir: &Path) -> Result<(Vec<PathBuf>, Vec<String>)> {
     fs::create_dir_all(&api_dir)?;
 
@@ -1119,7 +1129,7 @@ pub fn generate_wit_files(base_dir: &Path, api_dir: &Path) -> Result<(Vec<PathBu
     let mut processed_projects = Vec::new();
 
     if projects.is_empty() {
-        println!("No relevant Rust projects found.");
+        warn!("No relevant Rust projects found.");
         return Ok((Vec::new(), Vec::new()));
     }
 
@@ -1129,7 +1139,7 @@ pub fn generate_wit_files(base_dir: &Path, api_dir: &Path) -> Result<(Vec<PathBu
 
     let mut wit_worlds = HashSet::new();
     for project_path in &projects {
-        println!("Processing project: {}", project_path.display());
+        info!("Processing project: {}", project_path.display());
 
         match process_rust_project(project_path, api_dir) {
             Ok(Some((interface, wit_world))) => {
@@ -1140,15 +1150,15 @@ pub fn generate_wit_files(base_dir: &Path, api_dir: &Path) -> Result<(Vec<PathBu
 
                 wit_worlds.insert(wit_world);
             }
-            Ok(None) => println!("No import statement generated"),
-            Err(e) => println!("Error processing project: {}", e),
+            Ok(None) => warn!("No import statement generated"),
+            Err(e) => warn!("Error processing project: {}", e),
         }
     }
 
-    println!("Collected {} new imports", new_imports.len());
+    debug!("Collected {} new imports", new_imports.len());
 
     // Check for existing world definition files and update them
-    println!("Looking for existing world definition files");
+    debug!("Looking for existing world definition files");
     let mut updated_world = false;
 
     rewrite_wit(api_dir, &new_imports, &mut wit_worlds, &mut updated_world)?;
@@ -1157,7 +1167,7 @@ pub fn generate_wit_files(base_dir: &Path, api_dir: &Path) -> Result<(Vec<PathBu
     if !updated_world && !new_imports.is_empty() {
         // Define default world name
         let default_world = "async-app-template-dot-os-v0";
-        println!(
+        warn!(
             "No existing world definitions found, creating default with name: {}",
             default_world
         );
@@ -1189,7 +1199,7 @@ pub fn generate_wit_files(base_dir: &Path, api_dir: &Path) -> Result<(Vec<PathBu
         );
 
         let world_file = api_dir.join(format!("{}.wit", default_world));
-        println!(
+        info!(
             "Writing default world definition to {}",
             world_file.display()
         );
@@ -1201,9 +1211,9 @@ pub fn generate_wit_files(base_dir: &Path, api_dir: &Path) -> Result<(Vec<PathBu
             )
         })?;
 
-        println!("Successfully created default world definition");
+        info!("Successfully created default world definition");
     }
 
-    println!("WIT files generated successfully in the 'api' directory.");
+    info!("WIT files generated successfully in the 'api' directory.");
     Ok((processed_projects, interfaces))
 }


### PR DESCRIPTION
## Problem

Output after running 'kit b --hyperapp' is too verbose (everything was handled by println! macros). Slightly hard to understand and clogs the LLM context unnecessarily.

## Solution

Updated print statements into their respective categories. If dev/llm now wants to access detailed logs of WIT and caller utils generation, should just use: `RUST_LOG=debug kit b --hyperapp`

## Docs Update
TODO
[Corresponding docs PR](https://github.com/hyperware-ai/hyperdrive-book/pull/my-pr-number)

## Notes
when running `RUST_LOG=debug kit b --hyperapp`, things show up as expected, but this particular log seems to display a lot of times, which makes other log entries harder to see. I suggest trying to run it with some of your own projects and see whether the output includes what we want it to.
```bash
...
DEBUG src/build/mod.rs:674: get_most_recent_modified_time: most_recent: Some(SystemTime { tv_sec: 1745618203, tv_nsec: 532409368 }), most_recent_excluded: None
DEBUG src/build/mod.rs:674: get_most_recent_modified_time: most_recent: Some(SystemTime { tv_sec: 1745618203, tv_nsec: 544341034 }), most_recent_excluded: None
DEBUG src/build/mod.rs:674: get_most_recent_modified_time: most_recent: Some(SystemTime { tv_sec: 1745618203, tv_nsec: 523536015 }), most_recent_excluded: None
DEBUG src/build/mod.rs:674: get_most_recent_modified_time: most_recent: Some(SystemTime { tv_sec: 1745618203, tv_nsec: 540541841 }), most_recent_excluded: None
DEBUG src/build/mod.rs:674: get_most_recent_modified_time: most_recent: Some(SystemTime { tv_sec: 1745618203, tv_nsec: 535951726 }), most_recent_excluded: None
DEBUG src/build/mod.rs:674: get_most_recent_modified_time: most_recent: Some(SystemTime { tv_sec: 1745618203, tv_nsec: 747166189 }), most_recent_excluded: None
DEBUG src/build/mod.rs:674: get_most_recent_modified_time: most_recent: Some(SystemTime { tv_sec: 1745618203, tv_nsec: 745921931 }), most_recent_excluded: None
DEBUG src/build/mod.rs:674: get_most_recent_modified_time: most_recent: Some(SystemTime { tv_sec: 1745618203, tv_nsec: 749082619 }), most_recent_excluded: None
DEBUG src/build/mod.rs:674: get_most_recent_modified_time: most_recent: Some(SystemTime { tv_sec: 1745618203, tv_nsec: 764302100 }), most_recent_excluded: None
DEBUG src/build/mod.rs:674: get_most_recent_modified_time: most_recent: Some(SystemTime { tv_sec: 1745618203, tv_nsec: 764302100 }), most_recent_excluded: None
DEBUG src/build/mod.rs:674: get_most_recent_modified_time: most_recent: Some(SystemTime { tv_sec: 1745618203, tv_nsec: 545426833 }), most_recent_excluded: None
DEBUG src/build/mod.rs:674: get_most_recent_modified_time: most_recent: Some(SystemTime { tv_sec: 1745618203, tv_nsec: 537555821 }), most_recent_excluded: None
DEBUG src/build/mod.rs:674: get_most_recent_modified_time: most_recent: Some(SystemTime { tv_sec: 1745618203, tv_nsec: 545426833 }), most_recent_excluded: None
DEBUG src/build/mod.rs:674: get_most_recent_modified_time: most_recent: Some(SystemTime { tv_sec: 1745618203, tv_nsec: 595754349 }), most_recent_excluded: None
DEBUG src/build/mod.rs:674: get_most_recent_modified_time: most_recent: Some(SystemTime { tv_sec: 1745618203, tv_nsec: 606366714 }), most_recent_excluded: None
DEBUG src/build/mod.rs:674: get_most_recent_modified_time: most_recent: Some(SystemTime { tv_sec: 1745618203, tv_nsec: 606366714 }), most_recent_excluded: None
DEBUG src/build/mod.rs:674: get_most_recent_modified_time: most_recent: Some(SystemTime { tv_sec: 1745618203, tv_nsec: 539732669 }), most_recent_excluded: None
DEBUG src/build/mod.rs:674: get_most_recent_modified_time: most_recent: Some(SystemTime { tv_sec: 1745618203, tv_nsec: 536238603 }), most_recent_excluded: None
DEBUG src/build/mod.rs:674: get_most_recent_modified_time: most_recent: Some(SystemTime { tv_sec: 1745618203, tv_nsec: 551004872 }), most_recent_excluded: None
DEBUG src/build/mod.rs:674: get_most_recent_modified_time: most_recent: Some(SystemTime { tv_sec: 1745618203, tv_nsec: 527804670 }), most_recent_excluded: None
DEBUG src/build/mod.rs:674: get_most_recent_modified_time: most_recent: Some(SystemTime { tv_sec: 1745618203, tv_nsec: 644223684 }), most_recent_excluded: None
DEBUG src/build/mod.rs:674: get_most_recent_modified_time: most_recent: Some(SystemTime { tv_sec: 1745618203, tv_nsec: 647818668 }), most_recent_excluded: None
DEBUG src/build/mod.rs:674: get_most_recent_modified_time: most_recent: Some(SystemTime { tv_sec: 1745618203, tv_nsec: 647818668 }), most_recent_excluded: None
DEBUG src/build/mod.rs:674: get_most_recent_modified_time: most_recent: Some(SystemTime { tv_sec: 1745618203, tv_nsec: 647818668 }), most_recent_excluded: None
DEBUG src/build/mod.rs:674: get_most_recent_modified_time: most_recent: Some(SystemTime { tv_sec: 1745618203, tv_nsec: 647818668 }), most_recent_excluded: None
DEBUG src/build/mod.rs:674: get_most_recent_modified_time: most_recent: Some(SystemTime { tv_sec: 1745618203, tv_nsec: 545385125 }), most_recent_excluded: None
DEBUG src/build/mod.rs:674: get_most_recent_modified_time: most_recent: Some(SystemTime { tv_sec: 1745618203, tv_nsec: 545385125 }), most_recent_excluded: None
DEBUG src/build/mod.rs:674: get_most_recent_modified_time: most_recent: Some(SystemTime { tv_sec: 1745618203, tv_nsec: 554878316 }), most_recent_excluded: None
DEBUG src/build/mod.rs:674: get_most_recent_modified_time: most_recent: Some(SystemTime { tv_sec: 1745618203, tv_nsec: 519321069 }), most_recent_excluded: None
DEBUG src/build/mod.rs:674: get_most_recent_modified_time: most_recent: Some(SystemTime { tv_sec: 1745618203, tv_nsec: 565135303 }), most_recent_excluded: None
DEBUG src/build/mod.rs:674: get_most_recent_modified_time: most_recent: Some(SystemTime { tv_sec: 1745618203, tv_nsec: 569810669 }), most_recent_excluded: None
DEBUG src/build/mod.rs:674: get_most_recent_modified_time: most_recent: Some(SystemTime { tv_sec: 1745618203, tv_nsec: 952996282 }), most_recent_excluded: None
DEBUG src/build/mod.rs:674: get_most_recent_modified_time: most_recent: Some(SystemTime { tv_sec: 1745618203, tv_nsec: 730466157 }), most_recent_excluded: None
DEBUG src/build/mod.rs:674: get_most_recent_modified_time: most_recent: Some(SystemTime { tv_sec: 1745618203, tv_nsec: 550135366 }), most_recent_excluded: None
DEBUG src/build/mod.rs:674: get_most_recent_modified_time: most_recent: Some(SystemTime { tv_sec: 1745618203, tv_nsec: 530950275 }), most_recent_excluded: None
DEBUG src/build/mod.rs:674: get_most_recent_modified_time: most_recent: Some(SystemTime { tv_sec: 1745618203, tv_nsec: 523293847 }), most_recent_excluded: None
...
```
this here is just a snippet, there's a lot more. My goal was to have these logs available to the LLM should there be any issues, but this would only add garbage to the context.

