### PR TITLE
setup: add options & fix foundry (on linux)

### DIFF
--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -1469,14 +1469,14 @@ async fn check_and_populate_dependencies(
         if path.is_dir() {
             if path.join(RUST_SRC_PATH).exists() && !checked_rust && !skip_deps_check {
                 let deps = check_rust_deps()?;
-                get_deps(deps, &mut recv_kill, verbose).await?;
+                get_deps(deps, &mut recv_kill, false, verbose).await?;
                 checked_rust = true;
             } else if path.join(PYTHON_SRC_PATH).exists() && !checked_py {
                 check_py_deps()?;
                 checked_py = true;
             } else if path.join(JAVASCRIPT_SRC_PATH).exists() && !checked_js && !skip_deps_check {
                 let deps = check_js_deps()?;
-                get_deps(deps, &mut recv_kill, verbose).await?;
+                get_deps(deps, &mut recv_kill, false, verbose).await?;
                 checked_js = true;
             } else if Some("api") == path.file_name().and_then(|s| s.to_str()) {
                 // read api files: to be used in build
@@ -1859,7 +1859,7 @@ pub async fn execute(
         if !skip_deps_check {
             let mut recv_kill = make_fake_kill_chan();
             let deps = check_js_deps()?;
-            get_deps(deps, &mut recv_kill, verbose).await?;
+            get_deps(deps, &mut recv_kill, false, verbose).await?;
         }
         let valid_node = get_newest_valid_node_version(None, None)?;
         for ui_dir in ui_dirs {

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -257,7 +257,7 @@ pub async fn start_chain(
     tracing: bool,
 ) -> Result<Option<Child>> {
     let deps = check_foundry_deps()?;
-    get_deps(deps, &mut recv_kill, verbose).await?;
+    get_deps(deps, &mut recv_kill, false, verbose).await?;
 
     info!("Checking for Anvil on port {}...", port);
     if wait_for_anvil(port, 1, None).await.is_ok() {

--- a/src/dev_ui/mod.rs
+++ b/src/dev_ui/mod.rs
@@ -17,7 +17,7 @@ pub async fn execute(
     if !skip_deps_check {
         let deps = check_js_deps()?;
         let mut recv_kill = make_fake_kill_chan();
-        get_deps(deps, &mut recv_kill, false).await?;
+        get_deps(deps, &mut recv_kill, false, false).await?;
     }
     let valid_node = get_newest_valid_node_version(None, None)?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -481,7 +481,8 @@ async fn execute(
                 *foundry_optional,
                 *javascript_optional,
                 *verbose,
-            ).await
+            )
+            .await
         }
         Some(("start-package", matches)) => {
             let package_dir = PathBuf::from(matches.get_one::<String>("DIR").unwrap());

--- a/src/main.rs
+++ b/src/main.rs
@@ -472,6 +472,7 @@ async fn execute(
             let python_optional = matches.get_one::<bool>("PYTHON_OPTIONAL").unwrap();
             let foundry_optional = matches.get_one::<bool>("FOUNDRY_OPTIONAL").unwrap();
             let javascript_optional = matches.get_one::<bool>("JAVASCRIPT_OPTIONAL").unwrap();
+            let non_interactive = matches.get_one::<bool>("NON_INTERACTIVE").unwrap();
 
             let mut recv_kill = build::make_fake_kill_chan();
             setup::execute(
@@ -480,6 +481,7 @@ async fn execute(
                 *python_optional,
                 *foundry_optional,
                 *javascript_optional,
+                *non_interactive,
                 *verbose,
             )
             .await
@@ -1287,6 +1289,12 @@ async fn make_app(current_dir: &std::ffi::OsString) -> Result<Command> {
                 .short('j')
                 .long("javascript-optional")
                 .help("If set, don't require Javascript deps (just warn if missing)")
+                .required(false)
+            )
+            .arg(Arg::new("NON_INTERACTIVE")
+                .action(ArgAction::SetTrue)
+                .long("non-interactive")
+                .help("If set, do not prompt and instead always reply `Y` to prompts (i.e. automatically install dependencies without user input)")
                 .required(false)
             )
         )

--- a/src/main.rs
+++ b/src/main.rs
@@ -468,9 +468,20 @@ async fn execute(
         }
         Some(("setup", matches)) => {
             let verbose = matches.get_one::<bool>("VERBOSE").unwrap();
+            let docker_optional = matches.get_one::<bool>("DOCKER_OPTIONAL").unwrap();
+            let python_optional = matches.get_one::<bool>("PYTHON_OPTIONAL").unwrap();
+            let foundry_optional = matches.get_one::<bool>("FOUNDRY_OPTIONAL").unwrap();
+            let javascript_optional = matches.get_one::<bool>("JAVASCRIPT_OPTIONAL").unwrap();
 
             let mut recv_kill = build::make_fake_kill_chan();
-            setup::execute(&mut recv_kill, *verbose).await
+            setup::execute(
+                &mut recv_kill,
+                *docker_optional,
+                *python_optional,
+                *foundry_optional,
+                *javascript_optional,
+                *verbose,
+            ).await
         }
         Some(("start-package", matches)) => {
             let package_dir = PathBuf::from(matches.get_one::<String>("DIR").unwrap());
@@ -1247,6 +1258,34 @@ async fn make_app(current_dir: &std::ffi::OsString) -> Result<Command> {
                 .short('v')
                 .long("verbose")
                 .help("If set, output stdout and stderr")
+                .required(false)
+            )
+            .arg(Arg::new("DOCKER_OPTIONAL")
+                .action(ArgAction::SetTrue)
+                .short('d')
+                .long("docker-optional")
+                .help("If set, don't require Docker dep (just warn if missing)")
+                .required(false)
+            )
+            .arg(Arg::new("PYTHON_OPTIONAL")
+                .action(ArgAction::SetTrue)
+                .short('p')
+                .long("python-optional")
+                .help("If set, don't require Python dep (just warn if missing)")
+                .required(false)
+            )
+            .arg(Arg::new("FOUNDRY_OPTIONAL")
+                .action(ArgAction::SetTrue)
+                .short('f')
+                .long("foundry-optional")
+                .help("If set, don't require Foundry dep (just warn if missing)")
+                .required(false)
+            )
+            .arg(Arg::new("JAVASCRIPT_OPTIONAL")
+                .action(ArgAction::SetTrue)
+                .short('j')
+                .long("javascript-optional")
+                .help("If set, don't require Javascript deps (just warn if missing)")
                 .required(false)
             )
         )

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -404,70 +404,79 @@ pub fn check_docker_deps() -> Result<Vec<Dependency>> {
 pub async fn get_deps(
     deps: Vec<Dependency>,
     recv_kill: &mut BroadcastRecvBool,
+    non_interactive: bool,
     verbose: bool,
 ) -> Result<()> {
     if deps.is_empty() {
         return Ok(());
     }
 
-    // If setup required, request user permission
-    print!(
-        "kit requires {} missing {}: {}. Install? [Y/n]: ",
-        if deps.len() == 1 { "this" } else { "these" },
-        if deps.len() == 1 {
-            "dependency"
-        } else {
-            "dependencies"
-        },
-        Dependencies(deps.clone()),
-    );
-    // Flush to ensure the prompt is displayed before input
-    io::stdout().flush().unwrap();
+    if !non_interactive {
+        install_deps(deps, verbose)?;
+    } else {
+        // If setup required, request user permission
+        print!(
+            "kit requires {} missing {}: {}. Install? [Y/n]: ",
+            if deps.len() == 1 { "this" } else { "these" },
+            if deps.len() == 1 {
+                "dependency"
+            } else {
+                "dependencies"
+            },
+            Dependencies(deps.clone()),
+        );
+        // Flush to ensure the prompt is displayed before input
+        io::stdout().flush().unwrap();
 
-    // Read the user's response
-    let (sender, mut receiver) = tokio::sync::mpsc::channel(1);
-    tokio::spawn(async move {
-        let mut response = String::new();
-        io::stdin().read_line(&mut response).unwrap();
-        sender.send(response).await.unwrap();
-    });
+        // Read the user's response
+        let (sender, mut receiver) = tokio::sync::mpsc::channel(1);
+        tokio::spawn(async move {
+            let mut response = String::new();
+            io::stdin().read_line(&mut response).unwrap();
+            sender.send(response).await.unwrap();
+        });
 
-    // Process the response
-    let response = tokio::select! {
-        Some(response) = receiver.recv() => response,
-        k = recv_kill.recv() => {
-            match k {
-                Err(tokio::sync::broadcast::error::RecvError::Closed) => {
-                    // some systems drop the fake sender produced in build/mod.rs:57
-                    //  make_fake_kill_chan() and so we handle this by ignoring the
-                    //  Closed message that comes through
-                    //  https://docs.rs/tokio/latest/tokio/sync/broadcast/struct.Receiver.html#method.recv
-                    receiver.recv().await.unwrap()
-                }
-                _ => return Err(eyre!("got exit code")),
-            }
-        }
-    };
-    let response = response.trim().to_lowercase();
-    match response.as_str() {
-        "y" | "yes" | "" => {
-            for dep in deps {
-                match dep {
-                    Dependency::Nvm => install_nvm(verbose)?,
-                    Dependency::Npm => call_with_nvm(&format!("nvm install-latest-npm"), verbose)?,
-                    Dependency::Node => call_with_nvm(
-                        &format!("nvm install {}.{}", REQUIRED_NODE_MAJOR, MINIMUM_NODE_MINOR,),
-                        verbose,
-                    )?,
-                    Dependency::Rust => install_rust(verbose)?,
-                    Dependency::RustWasm32Wasi => call_rustup("target add wasm32-wasip1", verbose)?,
-                    Dependency::WasmTools => call_cargo("install wasm-tools", verbose)?,
-                    Dependency::Foundry => install_foundry(verbose)?,
-                    Dependency::Docker => {}
+        // Process the response
+        let response = tokio::select! {
+            Some(response) = receiver.recv() => response,
+            k = recv_kill.recv() => {
+                match k {
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                        // some systems drop the fake sender produced in build/mod.rs:57
+                        //  make_fake_kill_chan() and so we handle this by ignoring the
+                        //  Closed message that comes through
+                        //  https://docs.rs/tokio/latest/tokio/sync/broadcast/struct.Receiver.html#method.recv
+                        receiver.recv().await.unwrap()
+                    }
+                    _ => return Err(eyre!("got exit code")),
                 }
             }
+        };
+        let response = response.trim().to_lowercase();
+        match response.as_str() {
+            "y" | "yes" | "" => install_deps(deps, verbose)?,
+            r => warn!("Got '{}'; not getting deps.", r),
         }
-        r => warn!("Got '{}'; not getting deps.", r),
+    }
+    Ok(())
+}
+
+#[instrument(level = "trace", skip_all)]
+fn install_deps(deps: Vec<Dependency>, verbose: bool) -> Result<()> {
+    for dep in deps {
+        match dep {
+            Dependency::Nvm => install_nvm(verbose)?,
+            Dependency::Npm => call_with_nvm(&format!("nvm install-latest-npm"), verbose)?,
+            Dependency::Node => call_with_nvm(
+                &format!("nvm install {}.{}", REQUIRED_NODE_MAJOR, MINIMUM_NODE_MINOR,),
+                verbose,
+            )?,
+            Dependency::Rust => install_rust(verbose)?,
+            Dependency::RustWasm32Wasi => call_rustup("target add wasm32-wasip1", verbose)?,
+            Dependency::WasmTools => call_cargo("install wasm-tools", verbose)?,
+            Dependency::Foundry => install_foundry(verbose)?,
+            Dependency::Docker => {}
+        }
     }
     Ok(())
 }
@@ -479,6 +488,7 @@ pub async fn execute(
     python_optional: bool,
     foundry_optional: bool,
     javascript_optional: bool,
+    non_interactive: bool,
     verbose: bool,
 ) -> Result<()> {
     info!("Setting up...");
@@ -517,7 +527,7 @@ pub async fn execute(
         warn!("Foundry deps are not satisfied: {foundry_deps:?}");
     }
 
-    get_deps(missing_deps, recv_kill, verbose).await?;
+    get_deps(missing_deps, recv_kill, non_interactive, verbose).await?;
 
     info!("Done setting up.");
     Ok(())

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -411,7 +411,7 @@ pub async fn get_deps(
         return Ok(());
     }
 
-    if !non_interactive {
+    if non_interactive {
         install_deps(deps, verbose)?;
     } else {
         // If setup required, request user permission

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -501,11 +501,13 @@ pub async fn execute(
         warn!("JavaScript deps are not satisfied: {js_deps:?}");
     }
 
-    let mut docker_deps = check_docker_deps()?;
+    let docker_result = check_docker_deps();
     if !docker_optional {
-        missing_deps.append(&mut docker_deps);
+        missing_deps.append(&mut docker_result?);
     } else {
-        warn!("Docker deps are not satisfied: {docker_deps:?}");
+        if let Err(e) = docker_result {
+            warn!("Docker deps are not satisfied: {e}");
+        }
     }
 
     let mut foundry_deps = check_foundry_deps()?;


### PR DESCRIPTION
## Problem

Want to make use of `kit setup` but can't if only want a subset of deps.

## Solution

Allow each non-Rust deps to be opted out. Fix foundry.

## Docs Update

TODO

## Notes

None